### PR TITLE
Refactor users and audit modules for standardized API responses.

### DIFF
--- a/src/modules/audit/decorators/get-audit-by-action.decorator.ts
+++ b/src/modules/audit/decorators/get-audit-by-action.decorator.ts
@@ -1,46 +1,69 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiUnauthorizedResponse, ApiForbiddenResponse, ApiBearerAuth, ApiParam, ApiExtraModels } from "@nestjs/swagger";
-import { AuditLogListResponseDto } from "../dto/audit-response.dto";
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { AuditLogListResponseDto } from '../dto/audit-response.dto';
 import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetAuditByAction() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener registros de auditoría por acción - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de registros de auditoría filtrados por tipo de acción. Solo accesible para administradores.",
+      summary: 'Obtener registros de auditoría por acción - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de registros de auditoría filtrados por tipo de acción. Solo accesible para administradores.',
     }),
     ApiParam({
-      name: "action",
-      description: "Tipo de acción de auditoría a filtrar",
-      example: "CREATE",
-      enum: ["CREATE", "UPDATE", "DELETE", "LOGIN", "REGISTER"],
+      name: 'action',
+      description: 'Tipo de acción de auditoría a filtrar',
+      example: 'CREATE',
+      enum: ['CREATE', 'UPDATE', 'DELETE', 'LOGIN', 'REGISTER'],
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Registros de auditoría filtrados por acción obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description:
+        'Registros de auditoría filtrados por acción obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 401 },
-          message: { type: "string", example: "No autorizado" },
-          error: { type: "string", example: "Sin autorización" },
+          statusCode: { type: 'number', example: 401 },
+          message: { type: 'string', example: 'No autorizado' },
+          error: { type: 'string', example: 'Sin autorización' },
         },
       },
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 403 },
-          message: { type: "string", example: "Acceso denegado" },
-          error: { type: "string", example: "Prohibido" },
+          statusCode: { type: 'number', example: 403 },
+          message: { type: 'string', example: 'Acceso denegado' },
+          error: { type: 'string', example: 'Prohibido' },
         },
       },
     }),

--- a/src/modules/audit/decorators/get-audit-by-entity-type.decorator.ts
+++ b/src/modules/audit/decorators/get-audit-by-entity-type.decorator.ts
@@ -1,45 +1,68 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiUnauthorizedResponse, ApiForbiddenResponse, ApiBearerAuth, ApiParam, ApiExtraModels } from "@nestjs/swagger";
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { AuditLogListResponseDto } from '../dto/audit-response.dto';
 import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetAuditByEntityType() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener registros de auditoría por tipo de entidad - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de registros de auditoría filtrados por tipo de entidad. Solo accesible para administradores.",
+      summary: 'Obtener registros de auditoría por tipo de entidad - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de registros de auditoría filtrados por tipo de entidad. Solo accesible para administradores.',
     }),
     ApiParam({
-      name: "entityType",
-      description: "Tipo de entidad a filtrar (ej: User, BookCatalog, BookGenre)",
-      example: "User",
+      name: 'entityType',
+      description: 'Tipo de entidad a filtrar (ej: User, BookCatalog, BookGenre)',
+      example: 'User',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Registros de auditoría filtrados por tipo de entidad obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description:
+        'Registros de auditoría filtrados por tipo de entidad obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 401 },
-          message: { type: "string", example: "No autorizado" },
-          error: { type: "string", example: "Sin autorización" },
+          statusCode: { type: 'number', example: 401 },
+          message: { type: 'string', example: 'No autorizado' },
+          error: { type: 'string', example: 'Sin autorización' },
         },
       },
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 403 },
-          message: { type: "string", example: "Acceso denegado" },
-          error: { type: "string", example: "Prohibido" },
+          statusCode: { type: 'number', example: 403 },
+          message: { type: 'string', example: 'Acceso denegado' },
+          error: { type: 'string', example: 'Prohibido' },
         },
       },
     }),

--- a/src/modules/audit/decorators/get-audit-by-entity.decorator.ts
+++ b/src/modules/audit/decorators/get-audit-by-entity.decorator.ts
@@ -7,38 +7,52 @@ import {
   ApiNotFoundResponse,
   ApiBearerAuth,
   ApiParam,
-} from "@nestjs/swagger";
-import { AuditLogListResponseDto } from "../dto/audit-response.dto";
+  getSchemaPath,
+  ApiExtraModels,
+} from '@nestjs/swagger';
+import { AuditLogListResponseDto } from '../dto/audit-response.dto';
 import { PaginationDto } from '../../../common/dto';
-import { ApiExtraModels } from "@nestjs/swagger";
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetAuditByEntity() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener auditoría por entidad - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de registros de auditoría de una entidad específica. Solo accesible para administradores.",
+      summary: 'Obtener auditoría por entidad - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de registros de auditoría de una entidad específica. Solo accesible para administradores.',
     }),
     ApiParam({
-      name: "entityId",
+      name: 'entityId',
       type: String,
-      description: "ID único de la entidad para obtener su auditoría (UUID)",
-      example: "b8c4e4b2-1234-5678-9abc-def123456789",
+      description: 'ID único de la entidad para obtener su auditoría (UUID)',
+      example: 'b8c4e4b2-1234-5678-9abc-def123456789',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Registros de auditoría de la entidad obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description: 'Registros de auditoría de la entidad obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
     }),
     ApiNotFoundResponse({
-      description: "Entidad no encontrada con el ID proporcionado",
+      description: 'Entidad no encontrada con el ID proporcionado',
     }),
   );
 }

--- a/src/modules/audit/decorators/get-audit-by-user.decorator.ts
+++ b/src/modules/audit/decorators/get-audit-by-user.decorator.ts
@@ -8,37 +8,51 @@ import {
   ApiBearerAuth,
   ApiParam,
   ApiExtraModels,
-} from "@nestjs/swagger";
-import { AuditLogListResponseDto } from "../dto/audit-response.dto";
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { AuditLogListResponseDto } from '../dto/audit-response.dto';
 import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetAuditByUser() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener auditoría por usuario - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de registros de auditoría de un usuario específico. Solo accesible para administradores.",
+      summary: 'Obtener auditoría por usuario - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de registros de auditoría de un usuario específico. Solo accesible para administradores.',
     }),
     ApiParam({
-      name: "userId",
+      name: 'userId',
       type: String,
-      description: "ID único del usuario para obtener su auditoría (UUID)",
-      example: "b8c4e4b2-1234-5678-9abc-def123456789",
+      description: 'ID único del usuario para obtener su auditoría (UUID)',
+      example: 'b8c4e4b2-1234-5678-9abc-def123456789',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Registros de auditoría del usuario obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description: 'Registros de auditoría del usuario obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
     }),
     ApiNotFoundResponse({
-      description: "Usuario no encontrado con el ID proporcionado",
+      description: 'Usuario no encontrado con el ID proporcionado',
     }),
   );
 }

--- a/src/modules/audit/decorators/get-audit-logs.decorator.ts
+++ b/src/modules/audit/decorators/get-audit-logs.decorator.ts
@@ -1,40 +1,61 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiUnauthorizedResponse, ApiForbiddenResponse, ApiBearerAuth, ApiExtraModels } from "@nestjs/swagger";
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiBearerAuth,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { AuditLogListResponseDto } from '../dto/audit-response.dto';
 import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetAuditLogs() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener registros de auditoría - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de todos los registros de auditoría del sistema. Solo accesible para administradores.",
+      summary: 'Obtener registros de auditoría - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de todos los registros de auditoría del sistema. Solo accesible para administradores.',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Registros de auditoría obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description: 'Registros de auditoría obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 401 },
-          message: { type: "string", example: "No autorizado" },
-          error: { type: "string", example: "Sin autorización" },
+          statusCode: { type: 'number', example: 401 },
+          message: { type: 'string', example: 'No autorizado' },
+          error: { type: 'string', example: 'Sin autorización' },
         },
       },
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 403 },
-          message: { type: "string", example: "Acceso denegado" },
-          error: { type: "string", example: "Prohibido" },
+          statusCode: { type: 'number', example: 403 },
+          message: { type: 'string', example: 'Acceso denegado' },
+          error: { type: 'string', example: 'Prohibido' },
         },
       },
     }),

--- a/src/modules/audit/decorators/search-audit-logs.decorator.ts
+++ b/src/modules/audit/decorators/search-audit-logs.decorator.ts
@@ -1,55 +1,69 @@
 import { applyDecorators } from '@nestjs/common';
-import { 
-  ApiOperation, 
-  ApiResponse, 
+import {
+  ApiOperation,
+  ApiResponse,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiBearerAuth,
-  ApiQuery
+  ApiQuery,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { AuditLogListResponseDto } from '../dto/audit-response.dto';
-import { ApiExtraModels } from "@nestjs/swagger";
 import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiSearchAuditLogs() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Buscar registros de auditoría - Acceso: ADMIN",
-      description: "Busca registros de auditoría por término en el campo de detalles. Solo accesible para administradores.",
+      summary: 'Buscar registros de auditoría - Acceso: ADMIN',
+      description:
+        'Busca registros de auditoría por término en el campo de detalles. Solo accesible para administradores.',
     }),
     ApiQuery({
-      name: "term",
+      name: 'term',
       required: true,
       type: String,
-      description: "Término de búsqueda para filtrar por detalles de auditoría",
-      example: "john_doe",
+      description: 'Término de búsqueda para filtrar por detalles de auditoría',
+      example: 'john_doe',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, AuditLogListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Resultados de búsqueda de auditoría obtenidos exitosamente",
-      type: AuditLogListResponseDto,
+      description: 'Resultados de búsqueda de auditoría obtenidos exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(AuditLogListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 401 },
-          message: { type: "string", example: "No autorizado" },
-          error: { type: "string", example: "Sin autorización" },
+          statusCode: { type: 'number', example: 401 },
+          message: { type: 'string', example: 'No autorizado' },
+          error: { type: 'string', example: 'Sin autorización' },
         },
       },
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 403 },
-          message: { type: "string", example: "Acceso denegado" },
-          error: { type: "string", example: "Prohibido" },
+          statusCode: { type: 'number', example: 403 },
+          message: { type: 'string', example: 'Acceso denegado' },
+          error: { type: 'string', example: 'Prohibido' },
         },
       },
     }),

--- a/src/modules/users/decorators/create-user.decorator.ts
+++ b/src/modules/users/decorators/create-user.decorator.ts
@@ -1,25 +1,39 @@
-import { applyDecorators } from '@nestjs/common';
-import { 
-  ApiOperation, 
-  ApiResponse, 
-  ApiBadRequestResponse, 
+import { applyDecorators, Type } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBadRequestResponse,
   ApiConflictResponse,
   ApiForbiddenResponse,
-  ApiBearerAuth
+  ApiBearerAuth,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { CreateUserResponseDto } from '../dto';
+import { UserResponseDto } from '../dto/user-response.dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiCreateUser() {
   return applyDecorators(
     ApiBearerAuth('JWT-auth'),
-    ApiOperation({ 
+    ApiOperation({
       summary: 'Crear nuevo usuario - Acceso: ADMIN',
-      description: 'Crea un nuevo usuario en el sistema. Solo accesible para administradores.' 
+      description:
+        'Crea un nuevo usuario en el sistema. Solo accesible para administradores.',
     }),
-    ApiResponse({ 
-      status: 201, 
+    ApiResponse({
+      status: 201,
       description: 'Usuario creado exitosamente',
-      type: CreateUserResponseDto
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(UserResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiBadRequestResponse({
       description: 'Datos de entrada inválidos o errores de validación',
@@ -27,18 +41,18 @@ export function ApiCreateUser() {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 400 },
-          message: { 
-            type: 'array', 
+          message: {
+            type: 'array',
             items: { type: 'string' },
             example: [
               'El nombre de usuario debe tener al menos 3 caracteres',
               'Debe proporcionar un email válido',
-              'La contraseña debe tener al menos 6 caracteres'
-            ]
+              'La contraseña debe tener al menos 6 caracteres',
+            ],
           },
-          error: { type: 'string', example: 'Solicitud incorrecta' }
-        }
-      }
+          error: { type: 'string', example: 'Solicitud incorrecta' },
+        },
+      },
     }),
     ApiConflictResponse({
       description: 'El usuario ya existe en el sistema',
@@ -46,10 +60,13 @@ export function ApiCreateUser() {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 409 },
-          message: { type: 'string', example: 'El nombre de usuario ya está en uso' },
-          error: { type: 'string', example: 'Conflicto' }
-        }
-      }
+          message: {
+            type: 'string',
+            example: 'El nombre de usuario ya está en uso',
+          },
+          error: { type: 'string', example: 'Conflicto' },
+        },
+      },
     }),
     ApiForbiddenResponse({
       description: 'Acceso denegado - Se requieren permisos de administrador',
@@ -58,9 +75,9 @@ export function ApiCreateUser() {
         properties: {
           statusCode: { type: 'number', example: 403 },
           message: { type: 'string', example: 'Acceso denegado' },
-          error: { type: 'string', example: 'Prohibido' }
-        }
-      }
-    })
+          error: { type: 'string', example: 'Prohibido' },
+        },
+      },
+    }),
   );
 }

--- a/src/modules/users/decorators/delete-user.decorator.ts
+++ b/src/modules/users/decorators/delete-user.decorator.ts
@@ -1,43 +1,62 @@
 import { applyDecorators } from '@nestjs/common';
-import { 
-  ApiOperation, 
-  ApiResponse, 
+import {
+  ApiOperation,
+  ApiResponse,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiBearerAuth,
-  ApiParam
+  ApiParam,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { DeleteUserResponseDto } from '../dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiDeleteUser() {
   return applyDecorators(
     ApiBearerAuth('JWT-auth'),
-    ApiOperation({ 
+    ApiOperation({
       summary: 'Eliminar usuario del sistema - Acceso: ADMIN',
-      description: 'Realiza una eliminación lógica (soft delete) de un usuario del sistema. Solo accesible para administradores.' 
+      description:
+        'Realiza una eliminación lógica (soft delete) de un usuario del sistema. Solo accesible para administradores.',
     }),
     ApiParam({
       name: 'id',
       type: String,
       description: 'ID único del usuario a eliminar (UUID)',
-      example: 'b8c4e4b2-1234-5678-9abc-def123456789'
+      example: 'b8c4e4b2-1234-5678-9abc-def123456789',
     }),
-    ApiResponse({ 
-      status: 200, 
+    ApiResponse({
+      status: 200,
       description: 'Usuario eliminado exitosamente del sistema',
-      type: DeleteUserResponseDto
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string',
+                    example: 'b8c4e4b2-1234-5678-9abc-def123456789',
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
     }),
-    ApiUnauthorizedResponse({ 
+    ApiUnauthorizedResponse({
       description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 401 },
           message: { type: 'string', example: 'No autorizado' },
-          error: { type: 'string', example: 'Sin autorización' }
-        }
-      }
+          error: { type: 'string', example: 'Sin autorización' },
+        },
+      },
     }),
     ApiForbiddenResponse({
       description: 'Acceso denegado - Se requieren permisos de administrador',
@@ -46,9 +65,9 @@ export function ApiDeleteUser() {
         properties: {
           statusCode: { type: 'number', example: 403 },
           message: { type: 'string', example: 'Acceso denegado' },
-          error: { type: 'string', example: 'Prohibido' }
-        }
-      }
+          error: { type: 'string', example: 'Prohibido' },
+        },
+      },
     }),
     ApiNotFoundResponse({
       description: 'Usuario no encontrado con el ID proporcionado',
@@ -57,9 +76,9 @@ export function ApiDeleteUser() {
         properties: {
           statusCode: { type: 'number', example: 404 },
           message: { type: 'string', example: 'Usuario no encontrado' },
-          error: { type: 'string', example: 'No encontrado' }
-        }
-      }
-    })
+          error: { type: 'string', example: 'No encontrado' },
+        },
+      },
+    }),
   );
 }

--- a/src/modules/users/decorators/get-user-by-id.decorator.ts
+++ b/src/modules/users/decorators/get-user-by-id.decorator.ts
@@ -1,43 +1,57 @@
 import { applyDecorators } from '@nestjs/common';
-import { 
-  ApiOperation, 
-  ApiResponse, 
+import {
+  ApiOperation,
+  ApiResponse,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiBearerAuth,
-  ApiParam
+  ApiParam,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { UserResponseDto } from '../dto';
+import { UserResponseDto } from '../dto/user-response.dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetUserById() {
   return applyDecorators(
     ApiBearerAuth('JWT-auth'),
-    ApiOperation({ 
+    ApiOperation({
       summary: 'Obtener usuario por ID - Acceso: ADMIN',
-      description: 'Obtiene la información detallada de un usuario específico por su ID único.' 
+      description:
+        'Obtiene la información detallada de un usuario específico por su ID único.',
     }),
     ApiParam({
       name: 'id',
       type: String,
       description: 'ID único del usuario (UUID)',
-      example: 'b8c4e4b2-1234-5678-9abc-def123456789'
+      example: 'b8c4e4b2-1234-5678-9abc-def123456789',
     }),
-    ApiResponse({ 
-      status: 200, 
+    ApiResponse({
+      status: 200,
       description: 'Usuario encontrado exitosamente',
-      type: UserResponseDto
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(UserResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
-    ApiUnauthorizedResponse({ 
+    ApiUnauthorizedResponse({
       description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 401 },
           message: { type: 'string', example: 'No autorizado' },
-          error: { type: 'string', example: 'Sin autorización' }
-        }
-      }
+          error: { type: 'string', example: 'Sin autorización' },
+        },
+      },
     }),
     ApiForbiddenResponse({
       description: 'Acceso denegado - No tiene permisos para ver este usuario',
@@ -46,9 +60,9 @@ export function ApiGetUserById() {
         properties: {
           statusCode: { type: 'number', example: 403 },
           message: { type: 'string', example: 'Acceso denegado' },
-          error: { type: 'string', example: 'Prohibido' }
-        }
-      }
+          error: { type: 'string', example: 'Prohibido' },
+        },
+      },
     }),
     ApiNotFoundResponse({
       description: 'Usuario no encontrado con el ID proporcionado',
@@ -57,9 +71,9 @@ export function ApiGetUserById() {
         properties: {
           statusCode: { type: 'number', example: 404 },
           message: { type: 'string', example: 'Usuario no encontrado' },
-          error: { type: 'string', example: 'No encontrado' }
-        }
-      }
-    })
+          error: { type: 'string', example: 'No encontrado' },
+        },
+      },
+    }),
   );
 }

--- a/src/modules/users/decorators/get-users.decorator.ts
+++ b/src/modules/users/decorators/get-users.decorator.ts
@@ -1,40 +1,61 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiUnauthorizedResponse, ApiForbiddenResponse, ApiBearerAuth, ApiExtraModels } from "@nestjs/swagger";
-import { UserListResponseDto } from "../dto";
-import { PaginationDto } from "../../../common/dto";
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiBearerAuth,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { UserListResponseDto, UserResponseDto } from '../dto';
+import { PaginationDto } from '../../../common/dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiGetUsers() {
   return applyDecorators(
-    ApiBearerAuth("JWT-auth"),
+    ApiBearerAuth('JWT-auth'),
     ApiOperation({
-      summary: "Obtener lista de usuarios - Acceso: ADMIN",
-      description: "Obtiene una lista paginada de todos los usuarios del sistema. Solo accesible para administradores.",
+      summary: 'Obtener lista de usuarios - Acceso: ADMIN',
+      description:
+        'Obtiene una lista paginada de todos los usuarios del sistema. Solo accesible para administradores.',
     }),
-    ApiExtraModels(PaginationDto),
+    ApiExtraModels(PaginationDto, SuccessResponseDto, UserListResponseDto),
     ApiResponse({
       status: 200,
-      description: "Lista de usuarios obtenida exitosamente",
-      type: UserListResponseDto,
+      description: 'Lista de usuarios obtenida exitosamente',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(UserListResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiUnauthorizedResponse({
-      description: "No autorizado - Token JWT inválido o faltante",
+      description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 401 },
-          message: { type: "string", example: "No autorizado" },
-          error: { type: "string", example: "Sin autorización" },
+          statusCode: { type: 'number', example: 401 },
+          message: { type: 'string', example: 'No autorizado' },
+          error: { type: 'string', example: 'Sin autorización' },
         },
       },
     }),
     ApiForbiddenResponse({
-      description: "Acceso denegado - Se requieren permisos de administrador",
+      description: 'Acceso denegado - Se requieren permisos de administrador',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          statusCode: { type: "number", example: 403 },
-          message: { type: "string", example: "Acceso denegado" },
-          error: { type: "string", example: "Prohibido" },
+          statusCode: { type: 'number', example: 403 },
+          message: { type: 'string', example: 'Acceso denegado' },
+          error: { type: 'string', example: 'Prohibido' },
         },
       },
     }),

--- a/src/modules/users/decorators/update-user.decorator.ts
+++ b/src/modules/users/decorators/update-user.decorator.ts
@@ -1,34 +1,48 @@
 import { applyDecorators } from '@nestjs/common';
-import { 
-  ApiOperation, 
-  ApiResponse, 
+import {
+  ApiOperation,
+  ApiResponse,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiBadRequestResponse,
   ApiConflictResponse,
   ApiBearerAuth,
-  ApiParam
+  ApiParam,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { UpdateUserResponseDto } from '../dto';
+import { UserResponseDto } from '../dto/user-response.dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 export function ApiUpdateUser() {
   return applyDecorators(
     ApiBearerAuth('JWT-auth'),
-    ApiOperation({ 
+    ApiOperation({
       summary: 'Actualizar información de usuario - Acceso: ADMIN',
-      description: 'Actualiza la información de un usuario existente. Los usuarios pueden actualizar su propio perfil, los administradores pueden actualizar cualquier usuario.' 
+      description:
+        'Actualiza la información de un usuario existente. Los usuarios pueden actualizar su propio perfil, los administradores pueden actualizar cualquier usuario.',
     }),
     ApiParam({
       name: 'id',
       type: String,
       description: 'ID único del usuario a actualizar (UUID)',
-      example: 'b8c4e4b2-1234-5678-9abc-def123456789'
+      example: 'b8c4e4b2-1234-5678-9abc-def123456789',
     }),
-    ApiResponse({ 
-      status: 200, 
+    ApiResponse({
+      status: 200,
       description: 'Usuario actualizado exitosamente',
-      type: UpdateUserResponseDto
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(SuccessResponseDto) },
+          {
+            properties: {
+              data: {
+                $ref: getSchemaPath(UserResponseDto),
+              },
+            },
+          },
+        ],
+      },
     }),
     ApiBadRequestResponse({
       description: 'Datos de entrada inválidos o errores de validación',
@@ -36,39 +50,40 @@ export function ApiUpdateUser() {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 400 },
-          message: { 
-            type: 'array', 
+          message: {
+            type: 'array',
             items: { type: 'string' },
             example: [
               'El nombre de usuario debe tener al menos 3 caracteres',
-              'Debe proporcionar un email válido'
-            ]
+              'Debe proporcionar un email válido',
+            ],
           },
-          error: { type: 'string', example: 'Solicitud incorrecta' }
-        }
-      }
+          error: { type: 'string', example: 'Solicitud incorrecta' },
+        },
+      },
     }),
-    ApiUnauthorizedResponse({ 
+    ApiUnauthorizedResponse({
       description: 'No autorizado - Token JWT inválido o faltante',
       schema: {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 401 },
           message: { type: 'string', example: 'No autorizado' },
-          error: { type: 'string', example: 'Sin autorización' }
-        }
-      }
+          error: { type: 'string', example: 'Sin autorización' },
+        },
+      },
     }),
     ApiForbiddenResponse({
-      description: 'Acceso denegado - No tiene permisos para actualizar este usuario',
+      description:
+        'Acceso denegado - No tiene permisos para actualizar este usuario',
       schema: {
         type: 'object',
         properties: {
           statusCode: { type: 'number', example: 403 },
           message: { type: 'string', example: 'Acceso denegado' },
-          error: { type: 'string', example: 'Prohibido' }
-        }
-      }
+          error: { type: 'string', example: 'Prohibido' },
+        },
+      },
     }),
     ApiNotFoundResponse({
       description: 'Usuario no encontrado con el ID proporcionado',
@@ -77,9 +92,9 @@ export function ApiUpdateUser() {
         properties: {
           statusCode: { type: 'number', example: 404 },
           message: { type: 'string', example: 'Usuario no encontrado' },
-          error: { type: 'string', example: 'No encontrado' }
-        }
-      }
+          error: { type: 'string', example: 'No encontrado' },
+        },
+      },
     }),
     ApiConflictResponse({
       description: 'Conflicto - El nombre de usuario o email ya están en uso',
@@ -88,9 +103,9 @@ export function ApiUpdateUser() {
         properties: {
           statusCode: { type: 'number', example: 409 },
           message: { type: 'string', example: 'El email ya está registrado' },
-          error: { type: 'string', example: 'Conflicto' }
-        }
-      }
-    })
+          error: { type: 'string', example: 'Conflicto' },
+        },
+      },
+    }),
   );
 }

--- a/src/modules/users/dto/user-response.dto.ts
+++ b/src/modules/users/dto/user-response.dto.ts
@@ -2,54 +2,54 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '../enums/user-role.enum';
 
 export class UserResponseDto {
-  @ApiProperty({ 
-    description: 'ID único del usuario', 
-    example: 'b8c4e4b2-1234-5678-9abc-def123456789' 
+  @ApiProperty({
+    description: 'ID único del usuario',
+    example: 'b8c4e4b2-1234-5678-9abc-def123456789',
   })
   id: string;
 
-  @ApiProperty({ 
-    description: 'Nombre de usuario único', 
-    example: 'john_doe' 
+  @ApiProperty({
+    description: 'Nombre de usuario único',
+    example: 'john_doe',
   })
   username: string;
 
-  @ApiProperty({ 
-    description: 'Dirección de email del usuario', 
-    example: 'john@example.com' 
+  @ApiProperty({
+    description: 'Dirección de email del usuario',
+    example: 'john@example.com',
   })
   email: string;
 
-  @ApiProperty({ 
-    description: 'Rol del usuario en el sistema', 
+  @ApiProperty({
+    description: 'Rol del usuario en el sistema',
     enum: UserRole,
-    example: UserRole.USER
+    example: UserRole.USER,
   })
   role: UserRole;
 
   @ApiPropertyOptional({
     description: 'ID del rol personalizado asignado al usuario',
-    example: 'role-uuid-123'
+    example: 'role-uuid-123',
   })
   roleId?: string;
 
-  @ApiProperty({ 
-    description: 'Fecha de creación del usuario', 
-    example: '2024-01-01T00:00:00.000Z' 
+  @ApiProperty({
+    description: 'Fecha de creación del usuario',
+    example: '2024-01-01T00:00:00.000Z',
   })
   createdAt: Date;
 
-  @ApiProperty({ 
-    description: 'Fecha de última actualización del usuario', 
-    example: '2024-01-02T00:00:00.000Z' 
+  @ApiProperty({
+    description: 'Fecha de última actualización del usuario',
+    example: '2024-01-02T00:00:00.000Z',
   })
   updatedAt: Date;
 }
 
 export class UserListResponseDto {
-  @ApiProperty({ 
-    description: 'Lista de usuarios', 
-    type: [UserResponseDto] 
+  @ApiProperty({
+    description: 'Lista de usuarios',
+    type: [UserResponseDto],
   })
   data: UserResponseDto[];
 
@@ -61,8 +61,8 @@ export class UserListResponseDto {
       limit: 10,
       totalPages: 3,
       hasNext: true,
-      hasPrev: false
-    }
+      hasPrev: false,
+    },
   })
   meta: {
     total: number;
@@ -72,46 +72,4 @@ export class UserListResponseDto {
     hasNext: boolean;
     hasPrev: boolean;
   };
-}
-
-export class CreateUserResponseDto {
-  @ApiProperty({ 
-    description: 'Mensaje de confirmación', 
-    example: 'Usuario creado exitosamente' 
-  })
-  message: string;
-
-  @ApiProperty({ 
-    description: 'Información del usuario creado',
-    type: UserResponseDto
-  })
-  user: UserResponseDto;
-}
-
-export class UpdateUserResponseDto {
-  @ApiProperty({ 
-    description: 'Mensaje de confirmación', 
-    example: 'Usuario actualizado exitosamente' 
-  })
-  message: string;
-
-  @ApiProperty({ 
-    description: 'Información del usuario actualizado',
-    type: UserResponseDto
-  })
-  user: UserResponseDto;
-}
-
-export class DeleteUserResponseDto {
-  @ApiProperty({ 
-    description: 'Mensaje de confirmación', 
-    example: 'Usuario eliminado exitosamente' 
-  })
-  message: string;
-
-  @ApiProperty({ 
-    description: 'ID del usuario eliminado', 
-    example: 'b8c4e4b2-1234-5678-9abc-def123456789' 
-  })
-  deletedUserId: string;
 }

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -1,31 +1,43 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { IUserRepository } from '../interfaces/user.repository.interface';
-import { User } from "../entities/user.entity";
-import { CreateUserDto } from "../dto/create-user.dto";
-import { UpdateUserDto } from "../dto/update-user.dto";
-import { PaginationDto, PaginatedResult } from '../../../common/dto/pagination.dto';
-import { RegisterUserDto } from "../dto";
+import { User } from '../entities/user.entity';
+import { CreateUserDto } from '../dto/create-user.dto';
+import { UpdateUserDto } from '../dto/update-user.dto';
+import {
+  PaginationDto,
+  PaginatedResult,
+} from '../../../common/dto/pagination.dto';
+import { RegisterUserDto } from '../dto';
+import { SuccessResponseDto } from '../../../common/dto/success-response.dto';
 
 @Injectable()
 export class UserService {
   constructor(
-    @Inject("IUserRepository")
+    @Inject('IUserRepository')
     private readonly userRepository: IUserRepository,
   ) {}
 
-  async create(createUserDto: CreateUserDto, createdBy?: string): Promise<User> {
-    return await this.userRepository.registerUser(createUserDto, createdBy);
+  async create(
+    createUserDto: CreateUserDto,
+    createdBy?: string,
+  ): Promise<SuccessResponseDto<User>> {
+    return this.userRepository.registerUser(createUserDto, createdBy);
   }
 
-  async register(registerUser: RegisterUserDto, createdBy?: string): Promise<User> {
-    return await this.userRepository.registerUser(registerUser, createdBy);
+  async register(
+    registerUser: RegisterUserDto,
+    createdBy?: string,
+  ): Promise<SuccessResponseDto<User>> {
+    return this.userRepository.registerUser(registerUser, createdby);
   }
 
-  async findAll(pagination: PaginationDto): Promise<PaginatedResult<User>> {
+  async findAll(
+    pagination: PaginationDto,
+  ): Promise<SuccessResponseDto<PaginatedResult<User>>> {
     return this.userRepository.getAllUsers(pagination);
   }
 
-  async findById(id: string): Promise<User> {
+  async findById(id: string): Promise<SuccessResponseDto<User>> {
     return this.userRepository.getUserProfile(id);
   }
 
@@ -37,12 +49,18 @@ export class UserService {
     return this.userRepository.checkEmailExists(email);
   }
 
-  async update(id: string, updateUserDto: UpdateUserDto, updatedBy?: string): Promise<User> {
-    return await this.userRepository.updateUserProfile(id, updateUserDto, updatedBy);
+  async update(
+    id: string,
+    updateUserDto: UpdateUserDto,
+    updatedBy?: string,
+  ): Promise<SuccessResponseDto<User>> {
+    return this.userRepository.updateUserProfile(id, updateUserDto, updatedBy);
   }
 
-  async softDelete(id: string, deletedBy?: string): Promise<{ message: string }> {
-    await this.userRepository.deactivateUser(id, deletedBy);
-    return { message: "User deleted successfully" };
+  async softDelete(
+    id: string,
+    deletedBy?: string,
+  ): Promise<SuccessResponseDto<{ id: string }>> {
+    return this.userRepository.deactivateUser(id, deletedBy);
   }
 }


### PR DESCRIPTION
This commit aligns the `users` and `audit` modules with the new standardized API response structure using `SuccessResponseDto`.

Key changes:
- Refactored `user.service.ts` to correctly handle and return `SuccessResponseDto` from the repository layer.
- Updated all Swagger decorators (`@Api...`) in the `users` and `audit` modules to accurately document the `SuccessResponseDto` wrapper for single-entity, paginated, and other custom responses.
- Removed obsolete response DTO classes (`CreateUserResponseDto`, `UpdateUserResponseDto`, `DeleteUserResponseDto`) from the `users` module to clean up the codebase.
- The `audit.service.ts` was already aligned, so no changes were needed there.

This work is part of a larger effort to standardize the response structure across all modules. The `book-author-assignments`, `book-authors`, `book-catalog`, `book-genres`, `publishing-houses`, and `roles` modules have been identified for similar refactoring.